### PR TITLE
FEAT: #11 generate DM entity

### DIFF
--- a/backend/src/dm/entity/dm.entity.ts
+++ b/backend/src/dm/entity/dm.entity.ts
@@ -1,0 +1,32 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn} from 'typeorm';
+import { User } from "../../user/entity/user.entity";
+
+@Entity('direct_message')
+export class DirectMessage {
+  @PrimaryGeneratedColumn()
+  dmID: number;
+
+  @Column({ nullable: false, length: 255 })
+  message: string;
+
+  @Column({ type: "timestamp", default: () => "CURRENT_TIMESTAMP(6)"})
+  timestamp: Date;
+}
+
+@Entity('direct_message_info')
+export class DirectMessageInfo {
+  @ManyToOne(() => DirectMessage, dmID => dmID.dmID, { nullable: false })
+  @JoinColumn({ name: 'dmID' })
+  dmID: DirectMessage;
+
+  @ManyToOne(() => User, userID => userID.id, { primary: true, })
+  @JoinColumn({ name: 'userID' })
+  userID: User;
+
+  @ManyToOne(() => User, friendID => friendID.id, { primary: true, })
+  @JoinColumn({ name: 'friendID' })
+  friendID: User;
+
+  @Column({ nullable: false })
+  is_sender: boolean;
+}


### PR DESCRIPTION
## 작업 내용
- direct_message 테이블 구조
![image](https://user-images.githubusercontent.com/45448572/130574677-877cbfae-06c7-4443-80d7-28d4c5bc3178.png)


- direct_message_ info 테이블 구조
![image](https://user-images.githubusercontent.com/45448572/130574731-4e8c324a-375d-424e-a2a4-0368d1ceb3f7.png)


- 예시 : `user -> friend` `"this is test message!"` 전송
![image](https://user-images.githubusercontent.com/45448572/130574457-e92def22-a7a4-4550-be71-3d4074bf3a29.png)
![image](https://user-images.githubusercontent.com/45448572/130574403-888e6de1-758f-412c-9bc1-56ebd6b33709.png)

## 공유 사항
