### PR TITLE
Feat: #11 DM entity 작성 및 CR 테스트 완료

### DIFF
--- a/backend/src/dm/entity/dm.entity.ts
+++ b/backend/src/dm/entity/dm.entity.ts
@@ -1,0 +1,32 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn} from 'typeorm';
+import { User } from "../../user/entity/user.entity";
+
+@Entity('direct_message')
+export class DirectMessage {
+  @PrimaryGeneratedColumn()
+  dmID: number;
+
+  @Column({ nullable: false, length: 255 })
+  message: string;
+
+  @Column({ type: "timestamp", default: () => "CURRENT_TIMESTAMP(6)"})
+  timestamp: Date;
+}
+
+@Entity('direct_message_info')
+export class DirectMessageInfo {
+  @ManyToOne(() => DirectMessage, dmID => dmID.dmID, { nullable: false })
+  @JoinColumn({ name: 'dmID' })
+  dmID: DirectMessage;
+
+  @ManyToOne(() => User, userID => userID.id, { primary: true, })
+  @JoinColumn({ name: 'userID' })
+  userID: User;
+
+  @ManyToOne(() => User, friendID => friendID.id, { primary: true, })
+  @JoinColumn({ name: 'friendID' })
+  friendID: User;
+
+  @Column({ nullable: false })
+  is_sender: boolean;
+}

--- a/backend/src/dm/entity/dm.entity.ts
+++ b/backend/src/dm/entity/dm.entity.ts
@@ -28,5 +28,5 @@ export class DirectMessageInfo {
   friendID: User;
 
   @Column({ nullable: false })
-  is_sender: boolean;
+  isSender: boolean;
 }


### PR DESCRIPTION
## 작업 내용
- direct_message 테이블 구조
![image](https://user-images.githubusercontent.com/45448572/130577502-a0c3c4d9-fbfd-4330-95b1-1865adf27485.png)

- direct_message_ info 테이블 구조
![image](https://user-images.githubusercontent.com/45448572/130577562-20f0841c-ca21-4051-af88-272afceb64ca.png)

- API테스트 : `user -> friend` `"this is test message!"` 전송
![image](https://user-images.githubusercontent.com/45448572/130577669-fc001b0b-3e38-4f7c-a7fc-688fcbb47d82.png)
![image](https://user-images.githubusercontent.com/45448572/130577698-5a998727-552a-41d7-9ff1-8bb8a065da2d.png)


## 공유 사항
direct_message_ info 테이블에서 `is_sender` -> `isSender`로 수정했습니다
