### PR TITLE
FEAT: #25 add DM gateway

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1295,6 +1295,15 @@
         "tslib": "2.3.0"
       }
     },
+    "@nestjs/platform-socket.io": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-8.0.6.tgz",
+      "integrity": "sha512-974Yt8Jz7P69n4EqfR1mMzFFlb0Z+6bFCv0OAP3HrdZ71T/l4rd6OQ4+vhFvAMCxFmCh/JNWNZnYCY7e4x7oOA==",
+      "requires": {
+        "socket.io": "4.1.3",
+        "tslib": "2.3.0"
+      }
+    },
     "@nestjs/schematics": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-8.0.2.tgz",
@@ -1404,6 +1413,16 @@
       "integrity": "sha512-UHn4IsRkzm22eNDir/uI+x8gmgo66EO7SxWfVOiPpeLSdrTfZHKYz6q/P9KRgYbwXs8TrywVdIbJhp+4C0tzjQ==",
       "requires": {
         "uuid": "8.3.2"
+      }
+    },
+    "@nestjs/websockets": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-8.0.6.tgz",
+      "integrity": "sha512-xwPkzjdu0q9CKtrVaH5p+pyPHGa8M705voDsazcZVIsTy8f5n/P1sAmYEbQSe7vq6KqGgvp+B6axW7f63/8EKA==",
+      "requires": {
+        "iterare": "1.2.1",
+        "object-hash": "2.2.0",
+        "tslib": "2.3.0"
       }
     },
     "@nodelib/fs.scandir": {
@@ -1546,6 +1565,11 @@
         "@types/node": "*"
       }
     },
+    "@types/component-emitter": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
+      "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+    },
     "@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -1555,11 +1579,21 @@
         "@types/node": "*"
       }
     },
+    "@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+    },
     "@types/cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
+    },
+    "@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
     },
     "@types/eslint": {
       "version": "7.28.0",
@@ -1736,6 +1770,11 @@
       "requires": {
         "@types/superagent": "*"
       }
+    },
+    "@types/validator": {
+      "version": "13.6.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.6.3.tgz",
+      "integrity": "sha512-fWG42pMJOL4jKsDDZZREnXLjc3UE0R8LOJfARWYg6U966rxDT7TYejYzLnUF5cvSObGg34nd0+H2wHHU5Omdfw=="
     },
     "@types/yargs": {
       "version": "15.0.14",
@@ -2371,10 +2410,20 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-arraybuffer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
     },
     "base64url": {
       "version": "3.0.1",
@@ -2629,6 +2678,16 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "class-validator": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
+      "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
+      "requires": {
+        "@types/validator": "^13.1.3",
+        "libphonenumber-js": "^1.9.7",
+        "validator": "^13.5.2"
+      }
+    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -2795,8 +2854,7 @@
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-      "dev": true
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -3171,6 +3229,53 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "engine.io": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-5.1.1.tgz",
+      "integrity": "sha512-aMWot7H5aC8L4/T8qMYbLdvKlZOdJTH54FxfdFunTGvhMx1BHkJOntWArsVfgAZVwAO9LC2sryPWRcEeUzCe5w==",
+      "requires": {
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~4.0.0",
+        "ws": "~7.4.2"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "ws": {
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.2.tgz",
+      "integrity": "sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==",
+      "requires": {
+        "base64-arraybuffer": "0.1.4"
       }
     },
     "enhanced-resolve": {
@@ -5975,6 +6080,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.9.25",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.25.tgz",
+      "integrity": "sha512-LsSjcmXXGujESsrOsF2rrLdmuABj3OluCzPJKVNslJ2qc7xF5KdKXN8y0OcxHVurqosVf1/r4itrVrKSrlbVHA=="
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -7178,6 +7288,67 @@
         "is-fullwidth-code-point": "^3.0.0"
       }
     },
+    "socket.io": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.1.3.tgz",
+      "integrity": "sha512-tLkaY13RcO4nIRh1K2hT5iuotfTaIQw7cVIe0FUykN3SuQi0cm7ALxuyT5/CtDswOMWUzMGTibxYNx/gU7In+Q==",
+      "requires": {
+        "@types/cookie": "^0.4.0",
+        "@types/cors": "^2.8.10",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "debug": "~4.3.1",
+        "engine.io": "~5.1.1",
+        "socket.io-adapter": "~2.3.1",
+        "socket.io-parser": "~4.0.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.1.tgz",
+      "integrity": "sha512-8cVkRxI8Nt2wadkY6u60Y4rpW3ejA1rxgcK2JuyIhmF+RMNpTy1QRtkHIDUOf3B4HlQwakMsWbKftMv/71VMmw=="
+    },
+    "socket.io-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+      "requires": {
+        "@types/component-emitter": "^1.2.10",
+        "component-emitter": "~1.3.0",
+        "debug": "~4.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -7945,6 +8116,11 @@
         "convert-source-map": "^1.6.0",
         "source-map": "^0.7.3"
       }
+    },
+    "validator": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "@nestjs/platform-socket.io": "^8.0.6",
     "@nestjs/typeorm": "^8.0.2",
     "@nestjs/websockets": "^8.0.6",
+    "class-validator": "^0.13.1",
     "cookie-parser": "^1.4.5",
     "express-session": "^1.17.2",
     "passport": "^0.4.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { JwtMiddleware } from './auth/middleware/jwt.middleware';
 import { UserModule } from './user/user.module';
+import { DmModule } from './dm/dm.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { UserModule } from './user/user.module';
       }),
     }),
     UserModule,
+    DmModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -7,6 +7,7 @@ import { UserModule } from 'src/user/user.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { FTStrategy } from './strategy/ft.strategy';
+import { JwtStrategy } from './strategy/jwt.strategy';
 
 @Module({
   imports: [
@@ -23,7 +24,7 @@ import { FTStrategy } from './strategy/ft.strategy';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, FTStrategy],
-  exports: [AuthService, JwtModule],
+  providers: [AuthService, FTStrategy, JwtStrategy],
+  exports: [AuthService, JwtModule, JwtStrategy],
 })
 export class AuthModule {}

--- a/backend/src/auth/strategy/jwt.strategy.ts
+++ b/backend/src/auth/strategy/jwt.strategy.ts
@@ -5,8 +5,8 @@ import { Strategy } from 'passport-jwt';
 import { AuthService } from '../auth.service';
 import { JwtDto } from '../dto/jwt.dto';
 
-var cookieExtractor = function (req) {
-  var token = null;
+export const cookieExtractor = function (req) {
+  let token = null;
   if (req && req.cookies) {
     token = req.cookies['access_token'];
   }

--- a/backend/src/dm/dm.gateway.spec.ts
+++ b/backend/src/dm/dm.gateway.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DmGateway } from './dm.gateway';
+
+describe('DmGateway', () => {
+  let gateway: DmGateway;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DmGateway],
+    }).compile();
+
+    gateway = module.get<DmGateway>(DmGateway);
+  });
+
+  it('should be defined', () => {
+    expect(gateway).toBeDefined();
+  });
+});

--- a/backend/src/dm/dm.gateway.ts
+++ b/backend/src/dm/dm.gateway.ts
@@ -1,0 +1,61 @@
+import { JwtService } from '@nestjs/jwt';
+import { JwtStrategy } from 'src/auth/strategy/jwt.strategy';
+import { Logger } from '@nestjs/common';
+import {
+  MessageBody,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer
+} from '@nestjs/websockets';
+import { Server} from 'socket.io';
+import { DmService } from './dm.service';
+import { SendDMDto } from './dto/sendDM';
+import { SocketUser } from 'src/socket/socket-user';
+import { SocketUserService } from './socket-user.service';
+
+@WebSocketGateway()
+export class DmGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  constructor(
+    private jwtService: JwtService,
+    private jwtStrategy: JwtStrategy,
+    private readonly dmService: DmService,
+    private socketUserService: SocketUserService
+  ) {}
+  @WebSocketServer() server: Server;
+  private logger: Logger = new Logger('DmGateway');
+
+  async handleConnection (client: SocketUser) {
+    this.logger.log(`[connected] ${client.id}`);
+    try {
+      const userPayload = this.jwtService.verify(`${client.handshake.query.token}`);
+      const user = await this.jwtStrategy.validate(userPayload);
+      client.user = user;
+      this.socketUserService.addSocket(client);
+    } catch (error) {
+      client.disconnect(true);
+    }
+  }
+
+  async handleDisconnect (client: SocketUser) {
+    this.logger.log(`[disconnected] ${client.id}`);
+    try {
+      const userPayload = this.jwtService.verify(`${client.handshake.query.token}`);
+      const user = await this.jwtStrategy.validate(userPayload);
+      client.user = user;
+      this.socketUserService.removeSocket(client);
+
+    } catch (error) {}
+  }
+
+  @SubscribeMessage('dmToServer')
+  async handleMessage(@MessageBody() dm: SendDMDto) {
+    this.dmService.sendDM(dm);
+    const newDM = { senderID: dm.userID, message: dm.message };
+    const user = await this.socketUserService.getSocketById(dm.userID);
+    const friend = await this.socketUserService.getSocketById(dm.friendID);
+    if (user) user.emit('dmToClient', newDM);
+    if (friend) friend.emit('dmToClient', newDM);
+  }
+}

--- a/backend/src/dm/dm.module.ts
+++ b/backend/src/dm/dm.module.ts
@@ -1,12 +1,15 @@
 import { Module } from '@nestjs/common';
+import { AuthModule } from 'src/auth/auth.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DmController } from './dm.controller';
 import { DmService } from './dm.service';
 import { DirectMessage, DirectMessageInfo } from './entity/dm.entity';
+import { DmGateway } from './dm.gateway';
+import { SocketUserService } from './socket-user.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([DirectMessage, DirectMessageInfo])],
+  imports: [TypeOrmModule.forFeature([DirectMessage, DirectMessageInfo]), AuthModule],
   controllers: [DmController],
-  providers: [DmService]
+  providers: [DmService, DmGateway, SocketUserService]
 })
 export class DmModule {}

--- a/backend/src/dm/socket-user.service.ts
+++ b/backend/src/dm/socket-user.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { SocketUser } from 'src/socket/socket-user';
+
+@Injectable()
+export class SocketUserService {
+  private socketUser: Map<number, SocketUser> = new Map();
+
+  getSocketById(id: number): SocketUser {
+    return this.socketUser.get(id);
+  }
+
+  addSocket(socket: SocketUser) {
+    this.socketUser.set(socket.user.id, socket);
+  }
+
+  removeSocket(socket: SocketUser) {
+    this.socketUser.delete(socket.user.id);
+  }
+}

--- a/backend/src/socket/socket-user.ts
+++ b/backend/src/socket/socket-user.ts
@@ -1,0 +1,8 @@
+import { Socket } from 'socket.io';
+import { User } from 'src/user/entity/user.entity';
+
+interface WrapperUser {
+  user: User;
+}
+
+export interface SocketUser extends Socket, WrapperUser {}


### PR DESCRIPTION
## 작업 내용
- 클라이언트가 접속하면 JWT 토큰으로 유저를 식별하고, user id와 socket id를 `Map<>`으로 저장합니다 -> Game 팀과 같은 방식
- ` @SubscribeMessage('dmToServer')`로 받은 DM을 DB에 저장하고, `emit('dmToClient', newDM)`로 user 와 friend에게 전송합니다

## 공유 사항
Game 팀이 수정한 JwtService, JwtStrategy를 사용하기 때문에, src/auth 경로의 파일도 일부 업데이트되었습니다